### PR TITLE
Provide FormBindingFuncExtension types for a consistent interface

### DIFF
--- a/packages/core/src/binding.test.ts
+++ b/packages/core/src/binding.test.ts
@@ -1,12 +1,12 @@
 import { v4 as uuidV4 } from "uuid";
-import { FormBinding, FormBindingConstructor, FormBindingFunc } from "./binding";
+import { FormBinding, FormBindingConstructor, FormBindingFunc, FormBindingFuncExtension } from "./binding";
 import { Form } from "./Form";
 import { FormField } from "./FormField";
 
 export class SampleFormBinding implements FormBinding {
   readonly id = uuidV4();
 
-  constructor(private form: Form<unknown>) {
+  constructor(private form: Form<any>) {
     this.form = form;
   }
 
@@ -22,7 +22,7 @@ export class SampleConfigurableFormBinding implements FormBinding {
   readonly id = uuidV4();
 
   constructor(
-    private form: Form<unknown>,
+    private form: Form<any>,
     public config: { sample: boolean }
   ) {}
 
@@ -148,5 +148,115 @@ describe("FormBindingFunc", () => {
     bind("string", SampleConfigurableFieldBinding, { sample: true });
     bind(["string"], SampleMultiFieldBinding);
     bind(["string"], SampleConfigurableMultiFieldBinding, { sample: true });
+  });
+});
+
+describe("FormBindingFuncExtension", () => {
+  test("provides correct type definitions for form and field bindings", () => {
+    const bindForm1: FormBindingFuncExtension.ForForm.OptionalConfig<SampleModel, typeof SampleFormBinding> = () =>
+      ({}) as any;
+    bindForm1();
+    bindForm1({});
+    bindForm1({ cacheKey: "key" });
+
+    const bindForm2: FormBindingFuncExtension.ForForm.RequiredConfig<SampleModel, typeof SampleFormBinding> = () =>
+      ({}) as any;
+    // @ts-expect-error Expected 1 arguments, but got 0
+    bindForm2();
+    bindForm2({});
+    bindForm2({ cacheKey: "key" });
+
+    const bindForm3: FormBindingFuncExtension.ForForm.OptionalConfig<
+      SampleModel,
+      typeof SampleConfigurableFormBinding
+    > = () => ({}) as any;
+    bindForm3();
+    // @ts-expect-error Property 'sample' is missing
+    bindForm3({});
+    bindForm3({ sample: true });
+    bindForm3({ sample: true, cacheKey: "key" });
+
+    const bindForm4: FormBindingFuncExtension.ForForm.RequiredConfig<
+      SampleModel,
+      typeof SampleConfigurableFormBinding
+    > = () => ({}) as any;
+    // @ts-expect-error Expected 1 arguments, but got 0
+    bindForm4();
+    // @ts-expect-error Property 'sample' is missing
+    bindForm4({});
+    bindForm4({ sample: true });
+    bindForm4({ sample: true, cacheKey: "key" });
+
+    const bindField1: FormBindingFuncExtension.ForField.OptionalConfig<SampleModel, typeof SampleFieldBinding> = () =>
+      ({}) as any;
+    bindField1("string");
+    bindField1("string", {});
+    bindField1("string", { cacheKey: "key" });
+
+    const bindField2: FormBindingFuncExtension.ForField.RequiredConfig<SampleModel, typeof SampleFieldBinding> = () =>
+      ({}) as any;
+    // @ts-expect-error Expected 2 arguments, but got 1
+    bindField2("string");
+    bindField2("string", {});
+    bindField2("string", { cacheKey: "key" });
+
+    const bindField3: FormBindingFuncExtension.ForField.OptionalConfig<
+      SampleModel,
+      typeof SampleConfigurableFieldBinding
+    > = () => ({}) as any;
+    bindField3("string");
+    // @ts-expect-error Property 'sample' is missing
+    bindField3("string", {});
+    bindField3("string", { sample: true });
+    bindField3("string", { sample: true, cacheKey: "key" });
+
+    const bindField4: FormBindingFuncExtension.ForField.RequiredConfig<
+      SampleModel,
+      typeof SampleConfigurableFieldBinding
+    > = () => ({}) as any;
+    // @ts-expect-error Expected 2 arguments, but got 1
+    bindField4("string");
+    // @ts-expect-error Property 'sample' is missing
+    bindField4("string", {});
+    bindField4("string", { sample: true });
+    bindField4("string", { sample: true, cacheKey: "key" });
+
+    const bindMultiField1: FormBindingFuncExtension.ForMultiField.OptionalConfig<
+      SampleModel,
+      typeof SampleMultiFieldBinding
+    > = () => ({}) as any;
+    bindMultiField1(["string"]);
+    bindMultiField1(["string"], {});
+    bindMultiField1(["string"], { cacheKey: "key" });
+
+    const bindMultiField2: FormBindingFuncExtension.ForMultiField.RequiredConfig<
+      SampleModel,
+      typeof SampleMultiFieldBinding
+    > = () => ({}) as any;
+    // @ts-expect-error Expected 2 arguments, but got 1
+    bindMultiField2(["string"]);
+    bindMultiField2(["string"], {});
+    bindMultiField2(["string"], { cacheKey: "key" });
+
+    const bindMultiField3: FormBindingFuncExtension.ForMultiField.OptionalConfig<
+      SampleModel,
+      typeof SampleConfigurableMultiFieldBinding
+    > = () => ({}) as any;
+    bindMultiField3(["string"]);
+    // @ts-expect-error Property 'sample' is missing
+    bindMultiField3(["string"], {});
+    bindMultiField3(["string"], { sample: true });
+    bindMultiField3(["string"], { sample: true, cacheKey: "key" });
+
+    const bindMultiField4: FormBindingFuncExtension.ForMultiField.RequiredConfig<
+      SampleModel,
+      typeof SampleConfigurableMultiFieldBinding
+    > = () => ({}) as any;
+    // @ts-expect-error Expected 2 arguments, but got 1
+    bindMultiField4(["string"]);
+    // @ts-expect-error Property 'sample' is missing
+    bindMultiField4(["string"], {});
+    bindMultiField4(["string"], { sample: true });
+    bindMultiField4(["string"], { sample: true, cacheKey: "key" });
   });
 });

--- a/packages/core/src/binding.ts
+++ b/packages/core/src/binding.ts
@@ -48,7 +48,8 @@ export namespace FormBindingFunc {
     /** Create a binding for the field */
     <Binding extends new (field: FormField) => FormBinding>(
       fieldName: FormField.Name<T>,
-      binding: Binding
+      binding: Binding,
+      config?: Config
     ): InstanceType<Binding>["props"];
 
     /** Create a binding for the field with the config */
@@ -64,7 +65,8 @@ export namespace FormBindingFunc {
     /** Create a binding for the multiple fields */
     <Binding extends new (fields: FormField[]) => FormBinding>(
       fieldNames: FormField.Name<T>[],
-      binding: Binding
+      binding: Binding,
+      config?: Config
     ): InstanceType<Binding>["props"];
 
     /** Create a binding for the multiple fields with the config */
@@ -78,12 +80,63 @@ export namespace FormBindingFunc {
   /** Bind to the form */
   export interface ForForm<T> {
     /** Create a binding for the form */
-    <Binding extends new (form: Form<T>) => FormBinding>(binding: Binding): InstanceType<Binding>["props"];
+    <Binding extends new (form: Form<T>) => FormBinding>(
+      binding: Binding,
+      config?: Config
+    ): InstanceType<Binding>["props"];
 
     /** Create a binding for the form with the config */
     <Binding extends new (form: Form<T>, config: any) => FormBinding>(
       binding: Binding,
       config: NoInfer<ConfigOf<Binding>> & Config
     ): InstanceType<Binding>["props"];
+  }
+}
+
+export namespace FormBindingFuncExtension {
+  /** Bind configuration */
+  export type Config = FormBindingFunc.Config;
+
+  /** Bind to a field */
+  export namespace ForField {
+    /** Create a binding for the field with an optional config */
+    export type OptionalConfig<T, Binding extends new (field: FormField, config?: any) => FormBinding> = (
+      fieldName: FormField.Name<T>,
+      config?: NoInfer<ConfigOf<Binding>> & Config
+    ) => InstanceType<Binding>["props"];
+
+    /** Create a binding for the field with a required config */
+    export type RequiredConfig<T, Binding extends new (field: FormField, config: any) => FormBinding> = (
+      fieldName: FormField.Name<T>,
+      config: NoInfer<ConfigOf<Binding>> & Config
+    ) => InstanceType<Binding>["props"];
+  }
+
+  /** Bind to multiple fields */
+  export namespace ForMultiField {
+    /** Create a binding for the multiple fields */
+    export type OptionalConfig<T, Binding extends new (fields: FormField[], config?: any) => FormBinding> = (
+      fieldNames: FormField.Name<T>[],
+      config?: NoInfer<ConfigOf<Binding>> & Config
+    ) => InstanceType<Binding>["props"];
+
+    /** Create a binding for the multiple fields with the config */
+    export type RequiredConfig<T, Binding extends new (fields: FormField[], config: any) => FormBinding> = (
+      fieldNames: FormField.Name<T>[],
+      config: NoInfer<ConfigOf<Binding>> & Config
+    ) => InstanceType<Binding>["props"];
+  }
+
+  /** Bind to the form */
+  export namespace ForForm {
+    /** Create a binding for the form */
+    export type OptionalConfig<T, Binding extends new (form: Form<T>, config: any) => FormBinding> = (
+      config?: NoInfer<ConfigOf<Binding>> & Config
+    ) => InstanceType<Binding>["props"];
+
+    /** Create a binding for the form with the config */
+    export type RequiredConfig<T, Binding extends new (form: Form<T>, config: any) => FormBinding> = (
+      config: NoInfer<ConfigOf<Binding>> & Config
+    ) => InstanceType<Binding>["props"];
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export { Form } from "./Form";
 export { FormField } from "./FormField";
 export { FormConfig, configureForm } from "./config";
-export type { FormBinding } from "./binding";
+export type { FormBinding, FormBindingFuncExtension } from "./binding";
 export { FormDelegate, FormDelegated } from "./delegation";
 export type { FormValidationResult } from "./validation";

--- a/packages/react/src/extension.ts
+++ b/packages/react/src/extension.ts
@@ -1,4 +1,4 @@
-import { Form, FormField } from "@form-model/core";
+import { Form, FormBindingFuncExtension } from "@form-model/core";
 import { CheckBoxBinding } from "./CheckBoxBinding";
 import { InputBinding } from "./InputBinding";
 import { RadioButtonBinding } from "./RadioButtonBinding";
@@ -26,7 +26,7 @@ declare module "@form-model/core" {
      * />
      * ```
      */
-    bindInput(fieldName: FormField.Name<T>, config: InputBinding.Config): InputBinding["props"];
+    bindInput: FormBindingFuncExtension.ForField.RequiredConfig<T, typeof InputBinding>;
 
     /**
      * Bind the select box field to the form.
@@ -43,7 +43,7 @@ declare module "@form-model/core" {
      * </select>
      * ```
      */
-    bindSelectBox(fieldName: FormField.Name<T>, config: SelectBoxBinding.Config): SelectBoxBinding["props"];
+    bindSelectBox: FormBindingFuncExtension.ForField.RequiredConfig<T, typeof SelectBoxBinding>;
 
     /**
      * Bind the checkbox field to the form.
@@ -58,7 +58,7 @@ declare module "@form-model/core" {
      * />
      * ```
      */
-    bindCheckBox(fieldName: FormField.Name<T>, config: CheckBoxBinding.Config): CheckBoxBinding["props"];
+    bindCheckBox: FormBindingFuncExtension.ForField.RequiredConfig<T, typeof CheckBoxBinding>;
 
     /**
      * Bind the radio button field to the form.
@@ -76,7 +76,7 @@ declare module "@form-model/core" {
      * ))
      * ```
      */
-    bindRadioButton(fieldName: FormField.Name<T>, config: RadioButtonBinding.Config): RadioButtonBinding["props"];
+    bindRadioButton: FormBindingFuncExtension.ForField.RequiredConfig<T, typeof RadioButtonBinding>;
 
     /**
      * Bind the submit button to the form.
@@ -86,7 +86,7 @@ declare module "@form-model/core" {
      * <button {...form.bindSubmitButton()}>Submit</button>
      * ```
      */
-    bindSubmitButton(config?: SubmitButtonBinding.Config): SubmitButtonBinding["props"];
+    bindSubmitButton: FormBindingFuncExtension.ForForm.OptionalConfig<T, typeof SubmitButtonBinding>;
 
     /**
      * Bind the label to the form.
@@ -96,14 +96,14 @@ declare module "@form-model/core" {
      * <label {...form.bindLabel(["field1", "field2"])}>Label</label>
      * ```
      */
-    bindLabel(fields: FormField.Name<T>[], config?: LabelBinding.Config): LabelBinding["props"];
+    bindLabel: FormBindingFuncExtension.ForMultiField.OptionalConfig<T, typeof LabelBinding>;
   }
 }
 
 Form.prototype.bindInput = function (fieldName, config) {
   return this.bind(fieldName, InputBinding, {
-    cacheKey: config.valueAs,
     ...config,
+    cacheKey: `${config.valueAs}:${config.cacheKey}`,
   });
 };
 


### PR DESCRIPTION
## Why

`cacheKey` was missing in the React extension.


## Room for improvements

Generics handling...

```ts
  export interface Form<T> {
    bindChipInput<V>(
      fieldName: FormField.Name<T>,
      config: ChipInputBinding.Config<V> & FormBindingFuncExtension.Config
    ): ChipInputBinding<V>["props"];
  }
```