### PR TITLE
Protect binding cache from minification

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@form-model/core",
   "description": "MobX + Model x Form",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "creasty <yuki@creasty.com>",
   "license": "MIT",
   "homepage": "https://github.com/creasty/form-model",

--- a/packages/core/src/Form.ts
+++ b/packages/core/src/Form.ts
@@ -1,7 +1,7 @@
 import { action, computed, makeObservable, observable } from "mobx";
 import { v4 as uuidV4 } from "uuid";
 import { FormField } from "./FormField";
-import { FormBinding, FormBindingConstructor, FormBindingFunc } from "./binding";
+import { FormBinding, FormBindingConstructor, FormBindingFunc, getSafeBindingName } from "./binding";
 import { FormConfig, globalConfig } from "./config";
 import { Validation } from "./validation";
 import { FormDelegate, getDelegation, isConnectableObject } from "./delegation";
@@ -326,7 +326,7 @@ export class Form<T> {
     binding: FormBindingConstructor.ForForm,
     config?: FormBindingFunc.Config
   ) => {
-    const key = `${binding.name}:${config?.cacheKey}`;
+    const key = `${getSafeBindingName(binding)}:${config?.cacheKey}`;
     const instance = this.#defineBinding(key, () => new binding(this, config));
     instance.config = config; // Update on every call
     return instance.props;
@@ -338,7 +338,7 @@ export class Form<T> {
     binding: FormBindingConstructor.ForField,
     config?: FormBindingFunc.Config
   ) => {
-    const key = `${fieldName}@${binding.name}:${config?.cacheKey}`;
+    const key = `${fieldName}@${getSafeBindingName(binding)}:${config?.cacheKey}`;
     const instance = this.#defineBinding(key, () => {
       const field = this.getField(fieldName);
       return new binding(field, config);
@@ -353,7 +353,7 @@ export class Form<T> {
     binding: FormBindingConstructor.ForMultiField,
     config?: FormBindingFunc.Config
   ) => {
-    const key = `${fieldNames.join(",")}@${binding.name}:${config?.cacheKey}`;
+    const key = `${fieldNames.join(",")}@${getSafeBindingName(binding)}:${config?.cacheKey}`;
     const instance = this.#defineBinding(key, () => {
       const fields = fieldNames.map((name) => this.getField(name));
       return new binding(fields, config);

--- a/packages/core/src/binding.test.ts
+++ b/packages/core/src/binding.test.ts
@@ -1,5 +1,11 @@
 import { v4 as uuidV4 } from "uuid";
-import { FormBinding, FormBindingConstructor, FormBindingFunc, FormBindingFuncExtension } from "./binding";
+import {
+  FormBinding,
+  FormBindingConstructor,
+  FormBindingFunc,
+  FormBindingFuncExtension,
+  getSafeBindingName,
+} from "./binding";
 import { Form } from "./Form";
 import { FormField } from "./FormField";
 
@@ -98,6 +104,30 @@ export class SampleConfigurableMultiFieldBinding implements FormBinding {
 class SampleModel {
   string = "sample";
 }
+
+describe("getSafeBindingName", () => {
+  it("returns the same name for the same binding constructor", () => {
+    const name1 = getSafeBindingName(SampleFormBinding);
+    const name2 = getSafeBindingName(SampleFormBinding);
+    expect(name1).toBe(name2);
+  });
+
+  it("returns different names for different binding constructors", () => {
+    const name1 = getSafeBindingName(SampleFormBinding);
+    const name2 = getSafeBindingName(SampleFieldBinding);
+    expect(name1).not.toBe(name2);
+  });
+
+  it("returns different names for different binding constructors with the same Function.name", () => {
+    const SampleFormBinding1 = SampleFormBinding;
+    const SampleFormBinding2 = class SampleFormBinding extends SampleFormBinding1 {};
+
+    const name1 = getSafeBindingName(SampleFormBinding1);
+    const name2 = getSafeBindingName(SampleFormBinding2);
+    expect(SampleFormBinding1.name).toBe(SampleFormBinding2.name);
+    expect(name1).not.toBe(name2);
+  });
+});
 
 describe("FormBindingConstructor", () => {
   test("provides correct type definitions for form and field bindings", () => {

--- a/packages/core/src/binding.ts
+++ b/packages/core/src/binding.ts
@@ -1,5 +1,6 @@
 import type { Form } from "./Form";
 import type { FormField } from "./FormField";
+import { v4 as uuidV4 } from "uuid";
 
 type ConfigOf<T> = T extends new (form: Form<any>, config: infer Config) => FormBinding
   ? Config
@@ -30,6 +31,22 @@ export namespace FormBindingConstructor {
   /** Constructor for form binding classes */
   export type ForForm = new (form: Form<any>, config?: any) => FormBinding;
 }
+
+/**
+ * Get a safe name for the binding class
+ *
+ * Since Function.name is vulnerable to minification,
+ * a UUID is appended to the name to ensure uniqueness.
+ */
+export function getSafeBindingName(constructor: FormBindingConstructor): string {
+  let name = safeBindingNameCache.get(constructor);
+  if (!name) {
+    name = `${constructor.name}--${uuidV4()}`;
+    safeBindingNameCache.set(constructor, name);
+  }
+  return name;
+}
+const safeBindingNameCache = new WeakMap<FormBindingConstructor, string>();
 
 /** Polymorphic function of Form#bind */
 export interface FormBindingFunc<T>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@form-model/react",
   "description": "MobX + Model x Form",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "creasty <yuki@creasty.com>",
   "license": "MIT",
   "homepage": "https://github.com/creasty/form-model",


### PR DESCRIPTION
## Why

Function.name is not reliable in minified code.

## What

Ensures uniqueness by appending UUID.